### PR TITLE
feat: Added support for DuckDuckGo as a search API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,4 @@ html2text
 flask
 psutil
 pymongo
+ddgs

--- a/scrl/handler/config.yaml
+++ b/scrl/handler/config.yaml
@@ -1,5 +1,5 @@
 # Web Search Agent
-search_engine: "google" # "bing"
+search_engine: "google" # "google", "bing", "duckduckgo"
 search_top_k: 10
 search_region: "us"
 search_lang: "en"

--- a/scrl/handler/config.yaml
+++ b/scrl/handler/config.yaml
@@ -11,6 +11,11 @@ reading_agent_model: "qwen-plus"
 azure_bing_search_subscription_key: "key here if you use azure bing"
 azure_bing_search_mkt: "zh-CN" # "en-US"
 
+# DuckDuckGo settings (free search engine, rate-limited)
+duckduckgo_max_concurrent: 5   # max concurrent requests to DuckDuckGo
+duckduckgo_min_interval: 1.0   # min seconds between requests (per slot)
+duckduckgo_max_retries: 5      # max retries on rate limit errors
+
 query_save_path: "./scrl/handler/cache/search_result.json"
 
 server_url_list:

--- a/scrl/handler/handler.py
+++ b/scrl/handler/handler.py
@@ -34,6 +34,9 @@ class Handler:
     def search_and_add_to_dict(self, search_query, cur_api_result_dict, cur_api_result_dict_lock):
         try:
             organic = web_search(search_query, self.agent_config)
+            if organic is None:
+                print(f"Search failed for query '{search_query}', skipping cache")
+                return
             with cur_api_result_dict_lock:
                 cur_api_result_dict[search_query] = {
                     'timestamp': time.time(),
@@ -83,10 +86,11 @@ class Handler:
         
         for api_future in concurrent.futures.as_completed(api_future_list):
             api_future.result()
-        
+
         for key in cur_api_result_dict:
-            self.api_result_dict[key] = cur_api_result_dict[key]
-            
+            if cur_api_result_dict[key]['organic']:
+                self.api_result_dict[key] = cur_api_result_dict[key]
+
         with open(self.agent_config["query_save_path"], 'w', encoding='utf-8') as f:
             json.dump(self.api_result_dict, f, indent=4, ensure_ascii=False)
         print("缓存已保存", flush=True)
@@ -161,9 +165,10 @@ class Handler:
             
             for api_future in concurrent.futures.as_completed(api_future_list):
                 api_future.result()
-            
+
             for key in cur_api_result_dict:
-                self.api_result_dict[key] = cur_api_result_dict[key]
+                if cur_api_result_dict[key]['organic']:
+                    self.api_result_dict[key] = cur_api_result_dict[key]
                 
             with open(self.agent_config["query_save_path"], 'w', encoding='utf-8') as f:
                 json.dump(self.api_result_dict, f, indent=4, ensure_ascii=False)

--- a/scrl/handler/web_search_agent/search/search_api.py
+++ b/scrl/handler/web_search_agent/search/search_api.py
@@ -2,6 +2,7 @@ import requests
 import json
 import http.client
 import time
+from ddgs import DDGS
 
 
 def web_search(query, config):
@@ -21,6 +22,13 @@ def web_search(query, config):
             subscription_key=config['azure_bing_search_subscription_key'],
             mkt=config['azure_bing_search_mkt'],
             top_k=config['search_top_k']
+        )
+    elif config['search_engine'] == 'duckduckgo':
+        return duckduckgo_search(
+            query=query,
+            top_k=config['search_top_k'],
+            region=config.get('search_region', 'us'),
+            lang=config.get('search_lang', 'en')
         )
 
 
@@ -89,5 +97,22 @@ def serper_google_search(
     return []
 
 
+def duckduckgo_search(query, top_k=10, region='us', lang='en'):
+    results = []
+    try:
+        with DDGS() as ddgs:
+            search_results = ddgs.text(query, region=region, max_results=top_k)
+            for r in search_results:
+                results.append({
+                    "title": r.get("title", ""),
+                    "link": r.get("href", ""),
+                    "snippet": r.get("body", "")
+                })
+        print("duckduckgo search success")
+    except Exception as e:
+        print(f"DuckDuckGo search error: {e}")
+    return results
+
+
 if __name__ == "__main__":
-    print(serper_google_search("test", "your serper key",1,"us","en"))
+    print(duckduckgo_search("DeepResearcher project", top_k=3))

--- a/scrl/handler/web_search_agent/search/search_api.py
+++ b/scrl/handler/web_search_agent/search/search_api.py
@@ -2,7 +2,42 @@ import requests
 import json
 import http.client
 import time
+import threading
 from ddgs import DDGS
+
+_DDGS_SEMAPHORE = None
+_DDGS_MIN_INTERVAL = 1.0
+_DDGS_LAST_REQUEST_TIME = 0.0
+_DDGS_LOCK = threading.Lock()
+_DDGS_INITIALIZED = False
+
+
+def _ddgs_ensure_init(config):
+    global _DDGS_SEMAPHORE, _DDGS_MIN_INTERVAL, _DDGS_INITIALIZED
+    if not _DDGS_INITIALIZED:
+        _DDGS_SEMAPHORE = threading.Semaphore(config.get('duckduckgo_max_concurrent', 5))
+        _DDGS_MIN_INTERVAL = config.get('duckduckgo_min_interval', 1.0)
+        _DDGS_INITIALIZED = True
+
+
+def _ddgs_throttled_search(query, top_k, region, lang):
+    global _DDGS_LAST_REQUEST_TIME
+    with _DDGS_SEMAPHORE:
+        with _DDGS_LOCK:
+            elapsed = time.time() - _DDGS_LAST_REQUEST_TIME
+            if elapsed < _DDGS_MIN_INTERVAL:
+                time.sleep(_DDGS_MIN_INTERVAL - elapsed)
+            _DDGS_LAST_REQUEST_TIME = time.time()
+        with DDGS() as ddgs:
+            search_results = ddgs.text(query, region=region, max_results=top_k)
+            results = []
+            for r in search_results:
+                results.append({
+                    "title": r.get("title", ""),
+                    "link": r.get("href", ""),
+                    "snippet": r.get("body", "")
+                })
+            return results
 
 
 def web_search(query, config):
@@ -24,11 +59,13 @@ def web_search(query, config):
             top_k=config['search_top_k']
         )
     elif config['search_engine'] == 'duckduckgo':
+        _ddgs_ensure_init(config)
         return duckduckgo_search(
             query=query,
             top_k=config['search_top_k'],
             region=config.get('search_region', 'us'),
-            lang=config.get('search_lang', 'en')
+            lang=config.get('search_lang', 'en'),
+            max_retries=config.get('duckduckgo_max_retries', 5)
         )
 
 
@@ -97,21 +134,18 @@ def serper_google_search(
     return []
 
 
-def duckduckgo_search(query, top_k=10, region='us', lang='en'):
-    results = []
-    try:
-        with DDGS() as ddgs:
-            search_results = ddgs.text(query, region=region, max_results=top_k)
-            for r in search_results:
-                results.append({
-                    "title": r.get("title", ""),
-                    "link": r.get("href", ""),
-                    "snippet": r.get("body", "")
-                })
-        print("duckduckgo search success")
-    except Exception as e:
-        print(f"DuckDuckGo search error: {e}")
-    return results
+def duckduckgo_search(query, top_k=10, region='us', lang='en', max_retries=5):
+    for attempt in range(max_retries):
+        try:
+            results = _ddgs_throttled_search(query, top_k, region, lang)
+            print("duckduckgo search success")
+            return results
+        except Exception as e:
+            wait = min(2 ** attempt + 1, 30)
+            print(f"DuckDuckGo search error (attempt {attempt + 1}/{max_retries}): {e}, retrying in {wait}s")
+            time.sleep(wait)
+    print(f"DuckDuckGo search failed after {max_retries} retries: {query}")
+    return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request adds support for DuckDuckGo as a search engine option in the web search agent, in addition to the existing Google and Bing options. It introduces a new dependency, `ddgs`, and implements the logic for querying DuckDuckGo and parsing its results.

**Search Engine Support Enhancements:**

* Updated the `search_engine` configuration in `config.yaml` to document support for `"google"`, `"bing"`, and the newly added `"duckduckgo"` options.
* Added logic in `web_search` (in `search_api.py`) to handle the `"duckduckgo"` engine, calling a new `duckduckgo_search` function with appropriate parameters.
* Imported the `DDGS` library to enable DuckDuckGo search functionality.

**DuckDuckGo Search Implementation:**

* Implemented the `duckduckgo_search` function, which uses the `ddgs` library to perform searches, parse results, and handle errors gracefully.
* Updated the main script test to demonstrate the new DuckDuckGo search function.